### PR TITLE
Error check to pdsh function & add field for user to specify osd devices

### DIFF
--- a/cbt/benchmark/benchmark.py
+++ b/cbt/benchmark/benchmark.py
@@ -36,7 +36,7 @@ class Benchmark(object):
         print 'Setting OSD Read Ahead to: %s' % self.osd_ra
         self.cluster.set_osd_param('read_ahead_kb', self.osd_ra)
         print 'Cleaning existing temporary run directory: %s' % self.run_dir
-        common.pdsh(settings.getnodes('clients', 'osds', 'mons', 'rgws'), 'sudo rm -rf %s' % self.run_dir).communicate()
+        common.pdsh(settings.getnodes('clients', 'osds', 'mons', 'rgws'), 'sudo rm -rf %s' % self.run_dir)
         if self.valgrind is not None:
             print 'Adding valgrind to the command path.'
             self.cmd_path_full = common.setup_valgrind(self.valgrind, self.getclass(), self.run_dir)
@@ -49,8 +49,8 @@ class Benchmark(object):
     def dropcaches(self):
         nodes = settings.getnodes('clients', 'osds') 
 
-        common.pdsh(nodes, 'sync').communicate()
-        common.pdsh(nodes, 'echo 3 | sudo tee /proc/sys/vm/drop_caches').communicate()
+        common.pdsh(nodes, 'sync')
+        common.pdsh(nodes, 'echo 3 | sudo tee /proc/sys/vm/drop_caches')
 
     def __str__(self):
         return str(self.config)

--- a/cbt/benchmark/kvmrbdfio.py
+++ b/cbt/benchmark/kvmrbdfio.py
@@ -51,9 +51,9 @@ class KvmRbdFio(Benchmark):
         super(KvmRbdFio, self).initialize()
         for i in xrange(1):
              letter = string.ascii_lowercase[i+1]
-             common.pdsh(settings.getnodes('clients'), 'sudo mkfs.ext4 /dev/vd%s' % letter).communicate()
-             common.pdsh(settings.getnodes('clients'), 'sudo mkdir /srv/rbdfio-`hostname -s`-%d' % i).communicate()
-             common.pdsh(settings.getnodes('clients'), 'sudo mount -t ext4 -o noatime /dev/vd%s /srv/rbdfio-`hostname -s`-%d' %(letter, i)).communicate()
+             common.pdsh(settings.getnodes('clients'), 'sudo mkfs.ext4 /dev/vd%s' % letter)
+             common.pdsh(settings.getnodes('clients'), 'sudo mkdir /srv/rbdfio-`hostname -s`-%d' % i)
+             common.pdsh(settings.getnodes('clients'), 'sudo mount -t ext4 -o noatime /dev/vd%s /srv/rbdfio-`hostname -s`-%d' %(letter, i))
 
         # Create the run directory
         common.make_remote_dir(self.run_dir)
@@ -61,7 +61,7 @@ class KvmRbdFio(Benchmark):
         # populate the fio files
         print 'Attempting to populating fio files...'
         pre_cmd = 'sudo fio --rw=write -ioengine=sync --numjobs=%s --bs=4M --size %dM %s > /dev/null' % (self.numjobs, self.vol_size, self.names)
-        common.pdsh(settings.getnodes('clients'), pre_cmd).communicate()
+        common.pdsh(settings.getnodes('clients'), pre_cmd)
 
 
     def run(self):
@@ -106,22 +106,22 @@ class KvmRbdFio(Benchmark):
             self.cluster.create_recovery_test(self.run_dir, recovery_callback)
 
         print 'Running rbd fio %s test.' % self.mode
-        common.pdsh(settings.getnodes('clients'), fio_cmd).communicate()
+        common.pdsh(settings.getnodes('clients'), fio_cmd)
         monitoring.stop(self.run_dir)
 
         common.sync_files('%s/*' % self.run_dir, self.out_dir)
 
     def cleanup(self):
          super(KvmRbdFio, self).cleanup()
-         common.pdsh(settings.getnodes('clients'), 'sudo umount /srv/*').communicate()
+         common.pdsh(settings.getnodes('clients'), 'sudo umount /srv/*')
 
     def set_client_param(self, param, value):
          cmd = 'find /sys/block/vd* ! -iname vda -exec sudo sh -c "echo %s > {}/queue/%s" \;' % (value, param)
-         common.pdsh(settings.getnodes('clients'), cmd).communicate()
+         common.pdsh(settings.getnodes('clients'), cmd)
 
     def __str__(self):
         return "%s\n%s\n%s" % (self.run_dir, self.out_dir, super(KvmRbdFio, self).__str__())
 
     def recovery_callback(self):
-        common.pdsh(settings.getnodes('clients'), 'sudo killall fio').communicate()
+        common.pdsh(settings.getnodes('clients'), 'sudo killall fio')
 

--- a/cbt/benchmark/librbdfio.py
+++ b/cbt/benchmark/librbdfio.py
@@ -74,7 +74,7 @@ class LibrbdFio(Benchmark):
         # populate the fio files
         print 'Attempting to populating fio files...'
         pre_cmd = 'sudo %s --ioengine=rbd --clientname=admin --pool=%s --rbdname=cbt-librbdfio-`hostname -s` --invalidate=0  --rw=write --numjobs=%s --bs=4M --size %dM %s > /dev/null' % (self.cmd_path, self.poolname, self.numjobs, self.vol_size, self.names)
-        common.pdsh(settings.getnodes('clients'), pre_cmd).communicate()
+        common.pdsh(settings.getnodes('clients'), pre_cmd)
 
         return True
 
@@ -124,7 +124,7 @@ class LibrbdFio(Benchmark):
             self.cluster.create_recovery_test(self.run_dir, recovery_callback)
 
         print 'Running rbd fio %s test.' % self.mode
-        common.pdsh(settings.getnodes('clients'), fio_cmd).communicate()
+        common.pdsh(settings.getnodes('clients'), fio_cmd)
 
 
         # If we were doing recovery, wait until it's done.
@@ -143,11 +143,11 @@ class LibrbdFio(Benchmark):
         self.cluster.mkpool(self.poolname, self.pool_profile)
         for node in settings.getnodes('clients').split(','):
             node = node.rpartition("@")[2]
-            common.pdsh(settings.getnodes('head'), '/usr/bin/rbd create cbt-librbdfio-%s --size %s --pool %s --order %s' % (node, self.vol_size, self.poolname, self.vol_order)).communicate()
+            common.pdsh(settings.getnodes('head'), '/usr/bin/rbd create cbt-librbdfio-%s --size %s --pool %s --order %s' % (node, self.vol_size, self.poolname, self.vol_order))
         monitoring.stop()
 
     def recovery_callback(self): 
-        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 fio').communicate()
+        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 fio')
 
     def __str__(self):
         return "%s\n%s\n%s" % (self.run_dir, self.out_dir, super(LibrbdFio, self).__str__())

--- a/cbt/benchmark/radosbench.py
+++ b/cbt/benchmark/radosbench.py
@@ -110,7 +110,7 @@ class Radosbench(Benchmark):
         monitoring.stop()
 
     def recovery_callback(self): 
-        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 rados').communicate()
+        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 rados')
 
     def __str__(self):
         return "%s\n%s\n%s" % (self.run_dir, self.out_dir, super(Radosbench, self).__str__())

--- a/cbt/benchmark/rbdfio.py
+++ b/cbt/benchmark/rbdfio.py
@@ -74,7 +74,7 @@ class RbdFio(Benchmark):
         # populate the fio files
         print 'Attempting to populating fio files...'
         pre_cmd = 'sudo %s --ioengine=%s --rw=write --numjobs=%s --bs=4M --size %dM %s > /dev/null' % (self.cmd_path, self.ioengine, self.numjobs, self.vol_size*0.9, self.names)
-        common.pdsh(settings.getnodes('clients'), pre_cmd).communicate()
+        common.pdsh(settings.getnodes('clients'), pre_cmd)
 
         return True
 
@@ -123,7 +123,7 @@ class RbdFio(Benchmark):
         if self.log_avg_msec is not None:
             fio_cmd += ' --log_avg_msec=%s' % self.log_avg_msec
         print 'Running rbd fio %s test.' % self.mode
-        common.pdsh(settings.getnodes('clients'), fio_cmd).communicate()
+        common.pdsh(settings.getnodes('clients'), fio_cmd)
 
         # If we were doing recovery, wait until it's done.
         if 'recovery_test' in self.cluster.config:
@@ -139,7 +139,7 @@ class RbdFio(Benchmark):
         super(RbdFio, self).cleanup()
 
     def set_client_param(self, param, value):
-        common.pdsh(settings.getnodes('clients'), 'find /sys/block/rbd* -exec sudo sh -c "echo %s > {}/queue/%s" \;' % (value, param)).communicate()
+        common.pdsh(settings.getnodes('clients'), 'find /sys/block/rbd* -exec sudo sh -c "echo %s > {}/queue/%s" \;' % (value, param))
 
     def __str__(self):
         return "%s\n%s\n%s" % (self.run_dir, self.out_dir, super(RbdFio, self).__str__())
@@ -148,15 +148,15 @@ class RbdFio(Benchmark):
         monitoring.start("%s/pool_monitoring" % self.run_dir)
         self.cluster.rmpool(self.poolname, self.pool_profile)
         self.cluster.mkpool(self.poolname, self.pool_profile)
-        common.pdsh(settings.getnodes('clients'), '/usr/bin/rbd create cbt-kernelrbdfio-`hostname -s` --size %s --pool %s' % (self.vol_size, self.poolname)).communicate()
-        common.pdsh(settings.getnodes('clients'), 'sudo rbd map cbt-kernelrbdfio-`hostname -s` --pool %s --id admin' % self.poolname).communicate()
-        common.pdsh(settings.getnodes('clients'), 'sudo mkfs.xfs /dev/rbd/cbt-kernelrbdfio/cbt-kernelrbdfio-`hostname -s`').communicate()
-        common.pdsh(settings.getnodes('clients'), 'sudo mkdir -p -m0755 -- %s/mnt/cbt-kernelrbdfio-`hostname -s`' % self.cluster.tmp_dir).communicate()
-        common.pdsh(settings.getnodes('clients'), 'sudo mount -t xfs -o noatime,inode64 /dev/rbd/cbt-kernelrbdfio/cbt-kernelrbdfio-`hostname -s` %s/mnt/cbt-kernelrbdfio-`hostname -s`' % self.cluster.tmp_dir).communicate()
+        common.pdsh(settings.getnodes('clients'), '/usr/bin/rbd create cbt-kernelrbdfio-`hostname -s` --size %s --pool %s' % (self.vol_size, self.poolname))
+        common.pdsh(settings.getnodes('clients'), 'sudo rbd map cbt-kernelrbdfio-`hostname -s` --pool %s --id admin' % self.poolname)
+        common.pdsh(settings.getnodes('clients'), 'sudo mkfs.xfs /dev/rbd/cbt-kernelrbdfio/cbt-kernelrbdfio-`hostname -s`')
+        common.pdsh(settings.getnodes('clients'), 'sudo mkdir -p -m0755 -- %s/mnt/cbt-kernelrbdfio-`hostname -s`' % self.cluster.tmp_dir)
+        common.pdsh(settings.getnodes('clients'), 'sudo mount -t xfs -o noatime,inode64 /dev/rbd/cbt-kernelrbdfio/cbt-kernelrbdfio-`hostname -s` %s/mnt/cbt-kernelrbdfio-`hostname -s`' % self.cluster.tmp_dir)
         monitoring.stop()
 
     def recovery_callback(self): 
-        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 fio').communicate()
+        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 fio')
 
     def __str__(self):
         return "%s\n%s\n%s" % (self.run_dir, self.out_dir, super(LibrbdFio, self).__str__())

--- a/cbt/cbt.py
+++ b/cbt/cbt.py
@@ -26,6 +26,7 @@ def parse_args():
         help = 'YAML config file.',
         )
     args = parser.parse_args()
+    print args
     return args
 
 if __name__ == '__main__':

--- a/cbt/cluster/ceph.py
+++ b/cbt/cluster/ceph.py
@@ -41,15 +41,15 @@ class Ceph(Cluster):
         # Cleanup old junk and create new junk
         self.cleanup()
         common.mkdir_p(self.tmp_dir)
-        common.pdsh(settings.getnodes('head', 'clients', 'mons', 'osds', 'rgws', 'mds'), 'mkdir -p -m0755 -- %s' % self.tmp_dir).communicate()
-        common.pdsh(settings.getnodes('clients', 'mons', 'osds', 'rgws', 'mds'), 'mkdir -p -m0755 -- %s' % self.pid_dir).communicate()
-        common.pdsh(settings.getnodes('clients', 'mons', 'osds', 'rgws', 'mds'), 'mkdir -p -m0755 -- %s' % self.log_dir).communicate()
-        common.pdsh(settings.getnodes('clients', 'mons', 'osds', 'rgws', 'mds'), 'mkdir -p -m0755 -- %s' % self.monitoring_dir).communicate()
-        common.pdsh(settings.getnodes('clients', 'mons', 'osds', 'rgws', 'mds'), 'mkdir -p -m0755 -- %s' % self.core_dir).communicate()
+        common.pdsh(settings.getnodes('head', 'clients', 'mons', 'osds', 'rgws', 'mds'), 'mkdir -p -m0755 -- %s' % self.tmp_dir)
+        common.pdsh(settings.getnodes('clients', 'mons', 'osds', 'rgws', 'mds'), 'mkdir -p -m0755 -- %s' % self.pid_dir)
+        common.pdsh(settings.getnodes('clients', 'mons', 'osds', 'rgws', 'mds'), 'mkdir -p -m0755 -- %s' % self.log_dir)
+        common.pdsh(settings.getnodes('clients', 'mons', 'osds', 'rgws', 'mds'), 'mkdir -p -m0755 -- %s' % self.monitoring_dir)
+        common.pdsh(settings.getnodes('clients', 'mons', 'osds', 'rgws', 'mds'), 'mkdir -p -m0755 -- %s' % self.core_dir)
         self.distribute_conf()
 
         # Set the core directory
-        common.pdsh(settings.getnodes('clients', 'mons', 'osds', 'rgws', 'mds'), 'echo "%s/core.%%e.%%p.%%h.%%t" | sudo tee /proc/sys/kernel/core_pattern' % self.tmp_dir).communicate()
+        common.pdsh(settings.getnodes('clients', 'mons', 'osds', 'rgws', 'mds'), 'echo "%s/core.%%e.%%p.%%h.%%t" | sudo tee /proc/sys/kernel/core_pattern' % self.tmp_dir)
 
         # Create the filesystems
         self.setup_fs()
@@ -82,66 +82,93 @@ class Ceph(Cluster):
     def shutdown(self):
         nodes = settings.getnodes('clients', 'osds', 'mons', 'rgws', 'mds')
 
-        common.pdsh(nodes, 'sudo killall -9 massif-amd64-li').communicate()
-        common.pdsh(nodes, 'sudo killall -9 memcheck-amd64-').communicate()
-        common.pdsh(nodes, 'sudo killall -9 ceph-osd').communicate()
-        common.pdsh(nodes, 'sudo killall -9 ceph-mon').communicate()
-        common.pdsh(nodes, 'sudo killall -9 ceph-mds').communicate()
-        common.pdsh(nodes, 'sudo killall -9 rados').communicate()
-        common.pdsh(nodes, 'sudo killall -9 rest-bench').communicate()
-        common.pdsh(nodes, 'sudo killall -9 radosgw').communicate()
-        common.pdsh(nodes, 'sudo killall -9 radosgw-admin').communicate()
-        common.pdsh(nodes, 'sudo /etc/init.d/apache2 stop').communicate()
-        common.pdsh(nodes, 'sudo killall -9 pdsh').communicate()
+        common.pdsh(nodes, 'sudo killall -9 -q massif-amd64-li ', True)
+        common.pdsh(nodes, 'sudo killall -9 -q memcheck-amd64- ', True)
+        common.pdsh(nodes, 'sudo killall -9 -q ceph-osd', True)
+        common.pdsh(nodes, 'sudo killall -9 -q ceph-mon', True)
+        common.pdsh(nodes, 'sudo killall -9 -q ceph-mds', True)
+        common.pdsh(nodes, 'sudo killall -9 -q rados', True)
+        common.pdsh(nodes, 'sudo killall -9 -q rest-bench', True)
+        common.pdsh(nodes, 'sudo killall -9 -q radosgw', True)
+        common.pdsh(nodes, 'sudo killall -9 -q radosgw-admin', True)
+        common.pdsh(nodes, 'sudo /etc/init.d/apache2 stop', True)
+        common.pdsh(nodes, 'sudo killall -9 -q pdsh', True)
         monitoring.stop()
 
     def cleanup(self):
         nodes = settings.getnodes('clients', 'osds', 'mons', 'rgws', 'mds')
         print 'Deleting %s' % self.tmp_dir
-        common.pdsh(nodes, 'sudo rm -rf %s' % self.tmp_dir).communicate()
+        common.pdsh(nodes, 'sudo rm -rf %s' % self.tmp_dir)
 
-    def setup_fs(self):
+    def make_fs(self, osds, device, device_id):
         sc = settings.cluster
         fs = sc.get('fs')
         mkfs_opts = sc.get('mkfs_opts', '')
         mount_opts = sc.get('mount_opts', '')
+        
+        common.pdsh(osds, 'sudo umount %s' % device, True)
+        common.pdsh(osds, 'sudo rm -rf %s/osd-device-%s-data' % (self.mnt_dir, device_id))
+        common.pdsh(osds, 'sudo mkdir -p -m0755 -- %s/osd-device-%s-data' % (self.mnt_dir, device_id))
 
+        if fs == 'tmpfs':
+            print 'using tmpfs osds, not creating a file system.'
+        elif fs == 'zfs':
+            print 'ruhoh, zfs detected.  No mkfs for you!'
+            common.pdsh(osds, 'sudo zpool destroy osd-device-%s-data' % device_id)
+            common.pdsh(osds, 'sudo zpool create -f -O xattr=sa -m legacy osd-device-%s-data %s' % (device_id, device))
+            common.pdsh(osds, 'sudo zpool add osd-device-%s-data log /dev/disk/by-partlabel/osd-device-%s-zil' % (device_id, device_id))
+            common.pdsh(osds, 'sudo mount %s -t zfs osd-device-%s-data %s/osd-device-%s-data' % (mount_opts, device_id, self.mnt_dir, device_id))
+        else: 
+            common.pdsh(osds, 'sudo mkfs.%s %s %s' % (fs, mkfs_opts, device))
+            common.pdsh(osds, 'sudo mount %s -t %s %s %s/osd-device-%s-data' % (mount_opts, fs, device, self.mnt_dir, device_id))
+
+
+    def setup_fs(self):
+        sc = settings.cluster
+        fs = sc.get('fs')
+        
         if fs == '':
              shutdown("No OSD filesystem specified.  Exiting.")
 
-        for device in xrange (0,sc.get('osds_per_node')):
-            osds = settings.getnodes('osds')
-            common.pdsh(osds, 'sudo umount /dev/disk/by-partlabel/osd-device-%s-data' % device).communicate()
-            common.pdsh(osds, 'sudo rm -rf %s/osd-device-%s-data' % (self.mnt_dir, device)).communicate()
-            common.pdsh(osds, 'sudo mkdir -p -m0755 -- %s/osd-device-%s-data' % (self.mnt_dir, device)).communicate()
-
-            if fs == 'tmpfs':
-                print 'using tmpfs osds, not creating a file system.'
-            elif fs == 'zfs':
-                print 'ruhoh, zfs detected.  No mkfs for you!'
-                common.pdsh(osds, 'sudo zpool destroy osd-device-%s-data' % device).communicate()
-                common.pdsh(osds, 'sudo zpool create -f -O xattr=sa -m legacy osd-device-%s-data /dev/disk/by-partlabel/osd-device-%s-data' % (device, device)).communicate()
-                common.pdsh(osds, 'sudo zpool add osd-device-%s-data log /dev/disk/by-partlabel/osd-device-%s-zil' % (device, device)).communicate()
-                common.pdsh(osds, 'sudo mount %s -t zfs osd-device-%s-data %s/osd-device-%s-data' % (mount_opts, device, self.mnt_dir, device)).communicate()
-            else: 
-                common.pdsh(osds, 'sudo mkfs.%s %s /dev/disk/by-partlabel/osd-device-%s-data' % (fs, mkfs_opts, device)).communicate()
-                common.pdsh(osds, 'sudo mount %s -t %s /dev/disk/by-partlabel/osd-device-%s-data %s/osd-device-%s-data' % (mount_opts, fs, device, self.mnt_dir, device)).communicate()
-
+        osds = settings.getnodes('osds')
+        osds_mkfsed = False
+        user = sc.get('user')
+        device_id = 0
+        for osd in sc.get('osds'):
+            print osd
+            devices = sc.get(osd)
+            print devices
+            if not devices:
+                if not osds_mkfsed:
+                    break;
+                else:
+                    print "[ERROR] missing osd devices of "+osd
+                    sys.exit()
+            for device in devices:
+                self.make_fs( user+'@'+osd, device, device_id )
+                osds_mkfsed = True
+                device_id = device_id + 1
+       
+        if not osds_mkfsed: 
+            for device in xrange (0,sc.get('osds_per_node')):
+                self.make_fs( osds, "/dev/disk/by-partlabel/osd-device-"+str(device)+"-data", device )
+    
 
     def distribute_conf(self):
         nodes = settings.getnodes('head', 'clients', 'osds', 'mons', 'rgws')
         conf_file = self.config.get("conf_file")
         print "Distributing %s." % conf_file
-        common.pdcp(nodes, '', conf_file, self.tmp_conf).communicate()
-        common.pdsh(nodes, 'sudo mv /etc/ceph/ceph.conf /etc/ceph/ceph.conf.cbt.bak').communicate()
-        common.pdsh(nodes, 'sudo ln -s %s /etc/ceph/ceph.conf' % self.tmp_conf).communicate()
+        for node in nodes.split(","):
+            common.scp(node, conf_file, self.tmp_conf)
+        common.pdsh(nodes, 'sudo mv /etc/ceph/ceph.conf /etc/ceph/ceph.conf.cbt.bak', True)
+        common.pdsh(nodes, 'sudo ln -s %s /etc/ceph/ceph.conf' % self.tmp_conf)
 
     def make_mons(self):
         # Build and distribute the keyring
-        common.pdsh(settings.getnodes('head'), 'ceph-authtool --create-keyring --gen-key --name=mon. %s --cap mon \'allow *\'' % self.keyring_fn).communicate()
-        common.pdsh(settings.getnodes('head'), 'ceph-authtool --gen-key --name=client.admin --set-uid=0 --cap mon \'allow *\' --cap osd \'allow *\' --cap mds allow %s' % self.keyring_fn).communicate()
-        common.rscp(settings.getnodes('head'), self.keyring_fn, '%s.tmp' % self.keyring_fn).communicate()
-        common.pdcp(settings.getnodes('mons', 'osds', 'rgws', 'mds'), '', '%s.tmp' % self.keyring_fn, self.keyring_fn).communicate()
+        common.pdsh(settings.getnodes('head'), 'ceph-authtool --create-keyring --gen-key --name=mon. %s --cap mon \'allow *\'' % self.keyring_fn)
+        common.pdsh(settings.getnodes('head'), 'ceph-authtool --gen-key --name=client.admin --set-uid=0 --cap mon \'allow *\' --cap osd \'allow *\' --cap mds allow %s' % self.keyring_fn)
+        common.rscp(settings.getnodes('head'), self.keyring_fn, '%s.tmp' % self.keyring_fn)
+        common.pdcp(settings.getnodes('mons', 'osds', 'rgws', 'mds'), '', '%s.tmp' % self.keyring_fn, self.keyring_fn)
 
         # Build the monmap, retrieve it, and distribute it
         mons = settings.getnodes('mons').split(',')
@@ -152,9 +179,9 @@ class Ceph(Cluster):
            for mon, addr in mons.iteritems():
                 cmd = cmd + ' --add %s %s' % (mon, addr)
         cmd = cmd + ' --print %s' % self.monmap_fn
-        common.pdsh(settings.getnodes('head'), cmd).communicate()
-        common.rscp(settings.getnodes('head'), self.monmap_fn, '%s.tmp' % self.monmap_fn).communicate()
-        common.pdcp(settings.getnodes('mons'), '', '%s.tmp' % self.monmap_fn, self.monmap_fn).communicate()
+        common.pdsh(settings.getnodes('head'), cmd)
+        common.rscp(settings.getnodes('head'), self.monmap_fn, '%s.tmp' % self.monmap_fn)
+        common.pdcp(settings.getnodes('mons'), '', '%s.tmp' % self.monmap_fn, self.monmap_fn)
 
         # Build the ceph-mons
         user = settings.cluster.get('user')
@@ -162,10 +189,10 @@ class Ceph(Cluster):
             if user:
                 monhost = '%s@%s' % (user, monhost)
             for mon, addr in mons.iteritems():
-                common.pdsh(monhost, 'sudo rm -rf %s/mon.%s' % (self.tmp_dir, mon)).communicate()
-                common.pdsh(monhost, 'mkdir -p %s/mon.%s' % (self.tmp_dir, mon)).communicate()
-                common.pdsh(monhost, 'sudo sh -c "ulimit -c unlimited && exec %s --mkfs -c %s -i %s --monmap=%s --keyring=%s"' % (self.ceph_mon_cmd, self.tmp_conf, mon, self.monmap_fn, self.keyring_fn)).communicate()
-                common.pdsh(monhost, 'cp %s %s/mon.%s/keyring' % (self.keyring_fn, self.tmp_dir, mon)).communicate()
+                common.pdsh(monhost, 'sudo rm -rf %s/mon.%s' % (self.tmp_dir, mon))
+                common.pdsh(monhost, 'mkdir -p %s/mon.%s' % (self.tmp_dir, mon))
+                common.pdsh(monhost, 'sudo sh -c "ulimit -c unlimited && exec %s --mkfs -c %s -i %s --monmap=%s --keyring=%s"' % (self.ceph_mon_cmd, self.tmp_conf, mon, self.monmap_fn, self.keyring_fn), True)
+                common.pdsh(monhost, 'cp %s %s/mon.%s/keyring' % (self.keyring_fn, self.tmp_dir, mon))
             
         # Start the mons
         for monhost, mons in monhosts.iteritems():
@@ -178,7 +205,7 @@ class Ceph(Cluster):
                     cmd = "%s %s" % (common.setup_valgrind(self.mon_valgrind, 'mon.%s' % monhost, self.tmp_dir), cmd)
                 else:
                     cmd = 'ceph-run %s' % cmd
-                common.pdsh(monhost, 'sudo %s' % cmd).communicate()
+                common.pdsh(monhost, 'sudo %s' % cmd, True)
 
     def make_osds(self):
         osdnum = 0
@@ -193,10 +220,10 @@ class Ceph(Cluster):
                 # Build the OSD
                 osduuid = str(uuid.uuid4())
                 key_fn = '%s/osd-device-%s-data/keyring' % (self.mnt_dir, i)
-                common.pdsh(pdshhost, 'sudo ceph -c %s osd create %s' % (self.tmp_conf, osduuid)).communicate()
-                common.pdsh(pdshhost, 'sudo ceph -c %s osd crush add osd.%d 1.0 host=%s rack=localrack root=default' % (self.tmp_conf, osdnum, host)).communicate()
-                common.pdsh(pdshhost, 'sudo sh -c "ulimit -n 16384 && ulimit -c unlimited && exec %s -c %s -i %d --mkfs --mkkey --osd-uuid %s"' % (self.ceph_osd_cmd, self.tmp_conf, osdnum, osduuid)).communicate()
-                common.pdsh(pdshhost, 'sudo ceph -c %s -i %s auth add osd.%d osd "allow *" mon "allow profile osd"' % (self.tmp_conf, key_fn, osdnum)).communicate()
+                common.pdsh(pdshhost, 'sudo ceph -c %s osd create %s' % (self.tmp_conf, osduuid))
+                common.pdsh(pdshhost, 'sudo ceph -c %s osd crush add osd.%d 1.0 host=%s rack=localrack root=default' % (self.tmp_conf, osdnum, host), True)
+                common.pdsh(pdshhost, 'sudo sh -c "ulimit -n 16384 && ulimit -c unlimited && exec %s -c %s -i %d --mkfs --mkkey --osd-uuid %s"' % (self.ceph_osd_cmd, self.tmp_conf, osdnum, osduuid), True)
+                common.pdsh(pdshhost, 'sudo ceph -c %s -i %s auth add osd.%d osd "allow *" mon "allow profile osd"' % (self.tmp_conf, key_fn, osdnum), True)
 
                 # Start the OSD
                 pidfile="%s/ceph-osd.%d.pid" % (self.pid_dir, osdnum)
@@ -206,7 +233,7 @@ class Ceph(Cluster):
                 else:
                     cmd = 'ceph-run %s' % cmd
 
-                common.pdsh(pdshhost, 'sudo sh -c "ulimit -n 16384 && ulimit -c unlimited && exec %s"' % cmd).communicate()
+                common.pdsh(pdshhost, 'sudo sh -c "ulimit -n 16384 && ulimit -c unlimited && exec %s"' % cmd, True)
                 osdnum = osdnum+1
 
 
@@ -217,7 +244,7 @@ class Ceph(Cluster):
         ret = 0
 
         while True:
-            stdout, stderr = common.pdsh(settings.getnodes('head'), 'ceph -c %s health %s' % (self.tmp_conf, logline)).communicate()
+            stdout, stderr = common.pdsh(settings.getnodes('head'), 'ceph -c %s health %s' % (self.tmp_conf, logline))
             if "HEALTH_OK" in stdout:
                 break
             else:
@@ -229,7 +256,7 @@ class Ceph(Cluster):
     def check_scrub(self):
         print 'Waiting until Scrubbing completes...'
         while True:
-            stdout, stderr = common.pdsh(settings.getnodes('head'), 'ceph -c %s pg dump | cut -f 16 | grep "0.000000" | wc -l' % self.tmp_conf).communicate()
+            stdout, stderr = common.pdsh(settings.getnodes('head'), 'ceph -c %s pg dump | cut -f 16 | grep "0.000000" | wc -l' % self.tmp_conf)
             if " 0\n" in stdout:
                 break
             else:
@@ -237,10 +264,10 @@ class Ceph(Cluster):
             time.sleep(1)
 
     def dump_config(self, run_dir):
-        common.pdsh(settings.getnodes('osds'), 'sudo ceph -c %s --admin-daemon /var/run/ceph/ceph-osd.0.asok config show > %s/ceph_settings.out' % (self.tmp_conf, run_dir)).communicate()
+        common.pdsh(settings.getnodes('osds'), 'sudo ceph -c %s --admin-daemon /var/run/ceph/ceph-osd.0.asok config show > %s/ceph_settings.out' % (self.tmp_conf, run_dir))
 
     def dump_historic_ops(self, run_dir):
-        common.pdsh(settings.getnodes('osds'), 'find /var/run/ceph/*.asok -maxdepth 1 -exec sudo ceph --admin-daemon {} dump_historic_ops \; > %s/historic_ops.out' % run_dir).communicate()
+        common.pdsh(settings.getnodes('osds'), 'find /var/run/ceph/*.asok -maxdepth 1 -exec sudo ceph --admin-daemon {} dump_historic_ops \; > %s/historic_ops.out' % run_dir)
 
     def set_osd_param(self, param, value):
         common.pdsh(settings.getnodes('osds'), 'find /dev/disk/by-partlabel/osd-device-*data -exec readlink {} \; | cut -d"/" -f 3 | sed "s/[0-9]$//" | xargs -I{} sudo sh -c "echo %s > /sys/block/\'{}\'/queue/%s"' % (value, param))
@@ -275,26 +302,26 @@ class Ceph(Cluster):
     def make_profiles(self):
         crush_profiles = self.config.get('crush_profiles', {})
         for name,profile in crush_profiles.items():
-            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush add-bucket %s-root root' % (self.tmp_conf, name)).communicate()
-            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush add-bucket %s-rack rack' % (self.tmp_conf, name)).communicate()
-            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush move %s-rack root=%s-root' % (self.tmp_conf, name, name)).communicate()
+            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush add-bucket %s-root root' % (self.tmp_conf, name))
+            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush add-bucket %s-rack rack' % (self.tmp_conf, name))
+            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush move %s-rack root=%s-root' % (self.tmp_conf, name, name))
             # FIXME: We need to build a dict mapping OSDs to hosts and create a proper hierarchy!
-            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush add-bucket %s-host host' % (self.tmp_conf, name)).communicate()
-            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush move %s-host rack=%s-rack' % (self.tmp_conf, name, name)).communicate()
+            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush add-bucket %s-host host' % (self.tmp_conf, name))
+            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush move %s-host rack=%s-rack' % (self.tmp_conf, name, name))
             
             osds = profile.get('osds', None)
             if not osds:
                 raise Exception("No OSDs defined for crush profile, bailing!")
             for i in osds:
-                common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush set %s 1.0 host=%s-host' % (self.tmp_conf, i, name)).communicate()
-            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush rule create-simple %s %s-root osd' % (self.tmp_conf, name, name)).communicate()
+                common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush set %s 1.0 host=%s-host' % (self.tmp_conf, i, name))
+            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd crush rule create-simple %s %s-root osd' % (self.tmp_conf, name, name))
             self.set_ruleset(name)
 
         erasure_profiles = self.config.get('erasure_profiles', {})
         for name,profile in erasure_profiles.items():
             k = profile.get('erasure_k', 6)
             m = profile.get('erasure_m', 2)
-	    common.pdsh(settings.getnodes('head'), 'ceph -c %s osd erasure-code-profile set %s ruleset-failure-domain=osd k=%s m=%s' % (self.tmp_conf, name, k, m)).communicate()
+	    common.pdsh(settings.getnodes('head'), 'ceph -c %s osd erasure-code-profile set %s ruleset-failure-domain=osd k=%s m=%s' % (self.tmp_conf, name, k, m))
             self.set_ruleset(name)
 
     def mkpool(self, name, profile_name):
@@ -313,30 +340,30 @@ class Ceph(Cluster):
         target_max_objects = profile.get('target_max_objects', None)
         target_max_bytes = profile.get('target_max_bytes', None)
 
-#        common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool delete %s %s --yes-i-really-really-mean-it' % (self.tmp_conf, name, name)).communicate()
-        common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool create %s %d %d %s' % (self.tmp_conf, name, pg_size, pgp_size, erasure_profile)).communicate()
+#        common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool delete %s %s --yes-i-really-really-mean-it' % (self.tmp_conf, name, name))
+        common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool create %s %d %d %s' % (self.tmp_conf, name, pg_size, pgp_size, erasure_profile))
 
         if replication and replication == 'erasure':
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool create %s %d %d erasure %s' % (self.tmp_conf, name, pg_size, pgp_size, erasure_profile)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool create %s %d %d erasure %s' % (self.tmp_conf, name, pg_size, pgp_size, erasure_profile))
         else:
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool create %s %d %d' % (self.tmp_conf, name, pg_size, pgp_size)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool create %s %d %d' % (self.tmp_conf, name, pg_size, pgp_size))
 
         if replication and replication.isdigit():
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s size %s' % (self.tmp_conf, name, replication)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s size %s' % (self.tmp_conf, name, replication))
 
         if crush_profile:
             ruleset = self.get_ruleset(crush_profile)
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s crush_ruleset %s' % (self.tmp_conf, name, ruleset)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s crush_ruleset %s' % (self.tmp_conf, name, ruleset))
         if hit_set_type:
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s hit_set_type %s' % (self.tmp_conf, name, hit_set_type)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s hit_set_type %s' % (self.tmp_conf, name, hit_set_type))
         if hit_set_count:
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s hit_set_count %s' % (self.tmp_conf, name, hit_set_count)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s hit_set_count %s' % (self.tmp_conf, name, hit_set_count))
         if hit_set_period:
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s hit_set_period %s' % (self.tmp_conf, name, hit_set_period)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s hit_set_period %s' % (self.tmp_conf, name, hit_set_period))
         if target_max_objects:
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s target_max_objects %s' % (self.tmp_conf, name, target_max_objects)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s target_max_objects %s' % (self.tmp_conf, name, target_max_objects))
         if target_max_bytes:
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s target_max_bytes %s' % (self.tmp_conf, name, target_max_bytes)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool set %s target_max_bytes %s' % (self.tmp_conf, name, target_max_bytes))
         print 'Checking Healh after pool creation.'
         self.check_health()
 
@@ -346,9 +373,9 @@ class Ceph(Cluster):
             cache_mode = cache.get('mode', 'writeback')
             cache_name = '%s-cache' % name
             self.mkpool(cache_name, cache_profile)
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier add %s %s' % (self.tmp_conf, name, cache_name)).communicate()
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier cache-mode %s %s' % (self.tmp_conf, cache_name, cache_mode)).communicate()
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier set-overlay %s %s' % (self.tmp_conf, name, cache_name)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier add %s %s' % (self.tmp_conf, name, cache_name))
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier cache-mode %s %s' % (self.tmp_conf, cache_name, cache_mode))
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier set-overlay %s %s' % (self.tmp_conf, name, cache_name))
 
     def rmpool(self, name, profile_name):
         pool_profiles = self.config.get('pool_profiles', {'default': {}})
@@ -359,19 +386,19 @@ class Ceph(Cluster):
             cache_name = '%s-cache' % name
 
             # flush and remove the overlay and such
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier cache-mode %s forward' % (self.tmp_conf, cache_name)).communicate()
-            common.pdsh(settings.getnodes('head'), 'sudo rados -c %s -p %s cache-flush-evict-all' % (self.tmp_conf, cache_name)).communicate()
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier remove-overlay %s' % (self.tmp_conf, name)).communicate()
-            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier remove %s %s' % (self.tmp_conf, name, cache_name)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier cache-mode %s forward' % (self.tmp_conf, cache_name))
+            common.pdsh(settings.getnodes('head'), 'sudo rados -c %s -p %s cache-flush-evict-all' % (self.tmp_conf, cache_name))
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier remove-overlay %s' % (self.tmp_conf, name))
+            common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd tier remove %s %s' % (self.tmp_conf, name, cache_name))
 
             # delete the cache pool
             self.rmpool(cache_name, cache_profile)
-        common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool delete %s %s --yes-i-really-really-mean-it' % (self.tmp_conf, name, name)).communicate()
+        common.pdsh(settings.getnodes('head'), 'sudo ceph -c %s osd pool delete %s %s --yes-i-really-really-mean-it' % (self.tmp_conf, name, name))
 
     def rbd_unmount(self):
-        common.pdsh(settings.getnodes('clients'), 'sudo find /dev/rbd* -maxdepth 0 -type b -exec umount \'{}\' \;').communicate()
-#        common.pdsh(settings.getnodes('clients'), 'sudo find /dev/rbd* -maxdepth 0 -type b -exec rbd -c %s unmap \'{}\' \;' % self.tmp_conf).communicate()
-        common.pdsh(settings.getnodes('clients'), 'sudo service rbdmap stop').communicate()
+        #common.pdsh(settings.getnodes('clients'), 'sudo find /dev/rbd* -maxdepth 0 -type b -exec umount \'{}\' \;')
+#        common.pdsh(settings.getnodes('clients'), 'sudo find /dev/rbd* -maxdepth 0 -type b -exec rbd -c %s unmap \'{}\' \;' % self.tmp_conf)
+        common.pdsh(settings.getnodes('clients'), 'sudo service rbdmap stop')
 class RecoveryTestThread(threading.Thread):
     def __init__(self, config, cluster, callback):
         threading.Thread.__init__(self)
@@ -390,39 +417,39 @@ class RecoveryTestThread(threading.Thread):
 
     def pre(self):
         pre_time = self.config.get("pre_time", 60)
-        common.pdsh(settings.getnodes('head'), self.logcmd('Starting Recovery Test Thread, waiting %s seconds.' % pre_time)).communicate()
+        common.pdsh(settings.getnodes('head'), self.logcmd('Starting Recovery Test Thread, waiting %s seconds.' % pre_time))
         time.sleep(pre_time)
         lcmd = self.logcmd("Setting the ceph osd noup flag")
-        common.pdsh(settings.getnodes('head'), 'ceph -c %s ceph osd set noup;%s' % (self.cluster.tmp_conf, lcmd)).communicate()
+        common.pdsh(settings.getnodes('head'), 'ceph -c %s ceph osd set noup;%s' % (self.cluster.tmp_conf, lcmd))
         for osdnum in self.config.get('osds'):
             lcmd = self.logcmd("Marking OSD %s down." % osdnum)
-            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd down %s;%s' % (self.cluster.tmp_conf, osdnum, lcmd)).communicate()
+            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd down %s;%s' % (self.cluster.tmp_conf, osdnum, lcmd))
             lcmd = self.logcmd("Marking OSD %s out." % osdnum)
-            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd out %s;%s' % (self.cluster.tmp_conf, osdnum, lcmd)).communicate()
-        common.pdsh(settings.getnodes('head'), self.logcmd('Waiting for the cluster to break and heal')).communicate()
+            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd out %s;%s' % (self.cluster.tmp_conf, osdnum, lcmd))
+        common.pdsh(settings.getnodes('head'), self.logcmd('Waiting for the cluster to break and heal'))
 
         self.state = 'osdout'
 
     def osdout(self):
         ret = self.cluster.check_health("%s/recovery.log" % self.config.get('run_dir'))
-        common.pdsh(settings.getnodes('head'), self.logcmd("ret: %s" % ret)).communicate()
+        common.pdsh(settings.getnodes('head'), self.logcmd("ret: %s" % ret))
 
         if self.outhealthtries < self.maxhealthtries and ret == 0:
             self.outhealthtries = self.outhealthtries + 1
             return # Cluster hasn't become unhealthy yet.
 
         if ret == 0:
-            common.pdsh(settings.getnodes('head'), self.logcmd('Cluster never went unhealthy.')).communicate()
+            common.pdsh(settings.getnodes('head'), self.logcmd('Cluster never went unhealthy.'))
         else:
-            common.pdsh(settings.getnodes('head'), self.logcmd('Cluster appears to have healed.')).communicate()
+            common.pdsh(settings.getnodes('head'), self.logcmd('Cluster appears to have healed.'))
 
         lcmd = self.logcmd("Unsetting the ceph osd noup flag")
-        common.pdsh(settings.getnodes('head'), 'ceph -c %s ceph osd unset noup;%s' % (self.cluster.tmp_conf, lcmd)).communicate()
+        common.pdsh(settings.getnodes('head'), 'ceph -c %s ceph osd unset noup;%s' % (self.cluster.tmp_conf, lcmd))
         for osdnum in self.config.get('osds'):
             lcmd = self.logcmd("Marking OSD %s up." % osdnum)
-            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd up %s;%s' % (self.cluster.tmp_conf, osdnum, lcmd)).communicate()
+            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd up %s;%s' % (self.cluster.tmp_conf, osdnum, lcmd))
             lcmd = self.logcmd("Marking OSD %s in." % osdnum)
-            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd in %s;%s' % (self.cluster.tmp_conf, osdnum, lcmd)).communicate()
+            common.pdsh(settings.getnodes('head'), 'ceph -c %s osd in %s;%s' % (self.cluster.tmp_conf, osdnum, lcmd))
 
         self.state = "osdin"
 
@@ -434,27 +461,27 @@ class RecoveryTestThread(threading.Thread):
             return # Cluster hasn't become unhealthy yet.
 
         if ret == 0:
-            common.pdsh(settings.getnodes('head'), self.logcmd('Cluster never went unhealthy.')).communicate()
+            common.pdsh(settings.getnodes('head'), self.logcmd('Cluster never went unhealthy.'))
         else:
-            common.pdsh(settings.getnodes('head'), self.logcmd('Cluster appears to have healed.')).communicate()
+            common.pdsh(settings.getnodes('head'), self.logcmd('Cluster appears to have healed.'))
 
         post_time = self.config.get("post_time", 60)
-        common.pdsh(settings.getnodes('head'), self.logcmd('Cluster is healthy, completion in %s seconds.' % post_time)).communicate()
+        common.pdsh(settings.getnodes('head'), self.logcmd('Cluster is healthy, completion in %s seconds.' % post_time))
         time.sleep(post_time)
         self.state = "done"
 
     def done(self):
-        common.pdsh(settings.getnodes('head'), self.logcmd("Done.  Calling parent callback function.")).communicate()
+        common.pdsh(settings.getnodes('head'), self.logcmd("Done.  Calling parent callback function."))
         self.callback()
         self.stoprequest.set()
 
     def join(self, timeout=None):
-        common.pdsh(settings.getnodes('head'), self.logcmd('Received notification that parent is finished and waiting.')).communicate()
+        common.pdsh(settings.getnodes('head'), self.logcmd('Received notification that parent is finished and waiting.'))
         super(RecoveryTestThread, self).join(timeout)
 
     def run(self):
         self.stoprequest.clear()
         while not self.stoprequest.isSet():
           self.states[self.state]()
-        common.pdsh(settings.getnodes('head'), self.logcmd('Exiting recovery test thread.  Last state was: %s' % self.state)).communicate()
+        common.pdsh(settings.getnodes('head'), self.logcmd('Exiting recovery test thread.  Last state was: %s' % self.state))
 

--- a/cbt/common.py
+++ b/cbt/common.py
@@ -1,42 +1,48 @@
 import settings
+import sys
 import subprocess
 import time
 import os
 import errno
 
-def pdsh(nodes, command):
+def pdsh(nodes, command, force=False):
     args = ['pdsh', '-R', 'ssh', '-w', nodes, command]
     print('pdsh: %s' % args)
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    stdout, stderr = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True).communicate()
+    if force:
+        return
+    if stderr:
+        print "[ERROR]pdsh unable to finish the cmd\n  [STDOUT]:"+stdout+"\n  [STDERR]:"+stderr+"\n"
+        sys.exit()
 
 def pdcp(nodes, flags, localfile, remotefile):
     args = ['pdcp', '-f', '1', '-R', 'ssh', '-w', nodes, localfile, remotefile]
     if flags:
         args = ['pdcp', '-f', '1', '-R', 'ssh', '-w', nodes, flags, localfile, remotefile]
     print('pdcp: %s' % args)
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True).communicate()
 
 def rpdcp(nodes, flags, remotefile, localfile):
     args = ['rpdcp', '-f', '1', '-R', 'ssh', '-w', nodes, remotefile, localfile]
     if flags:
         args = ['rpdcp', '-f', '1', '-R', 'ssh', '-w', nodes, flags, remotefile, localfile]
     print('rpdcp: %s'  % args)
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True).communicate()
 
 def scp(node, localfile, remotefile):
     args = ['scp', localfile, '%s:%s' % (node, remotefile)]
     print('scp: %s' % args)
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True).communicate()
 
 def rscp(node, remotefile, localfile):
     args = ['scp', '%s:%s' % (node, remotefile), localfile]
     print('rscp: %s' % args)
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True).communicate()
 
 def make_remote_dir(remote_dir):
     print 'Making remote directory: %s' % remote_dir
     nodes = settings.getnodes('clients', 'osds', 'mons', 'rgws', 'mds')
-    pdsh(nodes, 'mkdir -p -m0755 -- %s' % remote_dir).communicate()
+    pdsh(nodes, 'mkdir -p -m0755 -- %s' % remote_dir)
 
 def sync_files(remote_dir, local_dir):
     nodes = settings.getnodes('clients', 'osds', 'mons', 'rgws', 'mds')
@@ -45,7 +51,7 @@ def sync_files(remote_dir, local_dir):
         os.makedirs(local_dir)
 
     pdsh(nodes, 'sudo chown -R %s.%s %s' % (settings.cluster.get('user'), settings.cluster.get('user'), remote_dir))
-    rpdcp(nodes, '-r', remote_dir, local_dir).communicate()
+    rpdcp(nodes, '-r', remote_dir, local_dir)
 
 def mkdir_p(path):
     try:

--- a/cbt/monitoring.py
+++ b/cbt/monitoring.py
@@ -10,14 +10,14 @@ def start(directory):
 
     # collectl
     common.pdsh(nodes, 'mkdir -p -m0755 -- %s' % collectl_dir)
-    common.pdsh(nodes, 'collectl -s+mYZ -i 1:10 -F0 -f %s' % collectl_dir)
+    common.pdsh(nodes, 'collectl -s+mYZ -D -i 1:10 -F0 -f %s' % collectl_dir)
 
     # perf
-#    common.pdsh(nodes), 'mkdir -p -m0755 -- %s' % perf_dir).communicate()
+#    common.pdsh(nodes), 'mkdir -p -m0755 -- %s' % perf_dir)
 #    common.pdsh(nodes), 'cd %s;sudo perf_3.6 record -g -f -a -F 100 -o perf.data' % perf_dir)
 
     # blktrace
-#    common.pdsh(osds, 'mkdir -p -m0755 -- %s' % blktrace_dir).communicate()
+#    common.pdsh(osds, 'mkdir -p -m0755 -- %s' % blktrace_dir)
 #    for device in xrange (0,osds_per_node):
 #        common.pdsh(osds, 'cd %s;sudo blktrace -o device%s -d /dev/disk/by-partlabel/osd-device-%s-data' % (blktrace_dir, device, device))
 
@@ -26,9 +26,9 @@ def start(directory):
 def stop(directory=None):
     nodes = settings.getnodes('clients', 'osds', 'mons', 'rgws')
 
-    common.pdsh(nodes, 'pkill -SIGINT -f collectl').communicate()
-    common.pdsh(nodes, 'sudo pkill -SIGINT -f perf_3.6').communicate()
-    common.pdsh(settings.getnodes('osds'), 'sudo pkill -SIGINT -f blktrace').communicate()
+    common.pdsh(nodes, 'pkill -SIGINT -f collectl', True)
+    common.pdsh(nodes, 'sudo pkill -SIGINT -f perf_3.6', True)
+    common.pdsh(settings.getnodes('osds'), 'sudo pkill -SIGINT -f blktrace', True)
     if directory:
         sc = settings.cluster
         common.pdsh(nodes, 'cd %s/perf;sudo chown %s.%s perf.data' % (directory, sc.get('user'), sc.get('user')))
@@ -40,5 +40,5 @@ def make_movies(directory):
     blktrace_dir = '%s/blktrace' % directory
 
     for device in xrange (0,sc.get('osds_per_node')):
-        common.pdsh(settings.getnodes('osds'), 'cd %s;%s -t device%s -o device%s.mpg --movie' % (blktrace_dir,seekwatcher,device,device)).communicate()
+        common.pdsh(settings.getnodes('osds'), 'cd %s;%s -t device%s -o device%s.mpg --movie' % (blktrace_dir,seekwatcher,device,device))
 

--- a/cbt/tmp.yaml
+++ b/cbt/tmp.yaml
@@ -1,0 +1,20 @@
+benchmarks:
+  radosbench: {}
+cluster:
+  cceph01: [/dev/sda1, /dev/sdb1, /dev/sdc1, /dev/sdd1, /dev/sde1, /dev/sdf1, /dev/sdg1,
+    /dev/sdh1]
+  cceph02: [/dev/sda1, /dev/sdb1, /dev/sdc1, /dev/sdd1, /dev/sde1, /dev/sdf1, /dev/sdg1,
+    /dev/sdh1]
+  clients: [cceph01, cceph02]
+  conf_file: ceph.conf
+  fs: xfs
+  head: cceph01
+  mkfs_opts: -f -i size=2048 -n size=64k
+  mons:
+    cceph01: {cceph01: 192.168.5.21}
+  mount_opts: -o inode64,noatime,logbsize=256k
+  osds: [cceph01, cceph02]
+  osds_per_node: 8
+  tmp_dir: /tmp/cbt
+  use_existing: true
+  user: root


### PR DESCRIPTION
1. Added error check in pdsh function
Currently, CBT runs pdsh command without error check,
thinking if we change the function to check stderr
when invoking pdsh will be more easy for users to hands on CBT and debuging

2. Adding new field in runtest.yaml to specify osd devices
+  cceph01: [/dev/sda1, /dev/sdb1, /dev/sdc1, /dev/sdd1, /dev/sde1, /dev/sdf1, /dev/sdg1, /dev/sdh1]
+  cceph02: [/dev/sda1, /dev/sdb1, /dev/sdc1, /dev/sdd1, /dev/sde1, /dev/sdf1, /dev/sdg1, /dev/sdh1]

If we specify osd devices in runtest.yaml, CBT will deploy to these
device rather than /dev/disk/by-partlabel/osd-device-%s-data

Signed-off-by: Chendi.Xue <chendi.xue@intel.com>

=============================

Also, I notice the runtest.yaml is out of date, so I submitted a refreshed yaml
I have tested it in my env to initialize ceph cluster successfully

+benchmarks:
+  radosbench: {}
+cluster:
+  cceph01: [/dev/sda1, /dev/sdb1, /dev/sdc1, /dev/sdd1, /dev/sde1, /dev/sdf1, /dev/sdg1,
+    /dev/sdh1]
+  cceph02: [/dev/sda1, /dev/sdb1, /dev/sdc1, /dev/sdd1, /dev/sde1, /dev/sdf1, /dev/sdg1,
+    /dev/sdh1]
+  clients: [cceph01, cceph02]
+  conf_file: ceph.conf
+  fs: xfs
+  head: cceph01
+  mkfs_opts: -f -i size=2048 -n size=64k
+  mons:
+    cceph01: {cceph01: 192.168.5.21}
+  mount_opts: -o inode64,noatime,logbsize=256k
+  osds: [cceph01, cceph02]
+  osds_per_node: 8
+  tmp_dir: /tmp/cbt
+  use_existing: true
+  user: root

